### PR TITLE
Florin/fix init data types

### DIFF
--- a/tornado-api/src/main/java/module-info.java
+++ b/tornado-api/src/main/java/module-info.java
@@ -46,4 +46,5 @@ module tornado.api {
     exports uk.ac.manchester.tornado.api.types.vectors;
     opens uk.ac.manchester.tornado.api.types.vectors;
     exports uk.ac.manchester.tornado.api.types;
+    opens uk.ac.manchester.tornado.api.types;
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -24,7 +24,6 @@ import java.lang.foreign.MemorySegment;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
-import uk.ac.manchester.tornado.api.types.HalfFloat;
 
 /**
  * This class represents an array of ints stored in native memory.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/utils/TornadoAPIUtils.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/utils/TornadoAPIUtils.java
@@ -17,6 +17,8 @@
  */
 package uk.ac.manchester.tornado.api.utils;
 
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 
@@ -129,6 +131,8 @@ public final class TornadoAPIUtils {
             isBox = true;
         } else if (obj instanceof Short) {
             isBox = true;
+        } else if (obj instanceof HalfFloat) {
+            isBox = true;
         } else if (obj instanceof Integer) {
             isBox = true;
         } else if (obj instanceof Long) {
@@ -159,6 +163,8 @@ public final class TornadoAPIUtils {
         } else if (clazz == Character.class) {
             isBox = true;
         } else if (clazz == Short.class) {
+            isBox = true;
+        } else if (clazz == HalfFloat.class) {
             isBox = true;
         } else if (clazz == Integer.class) {
             isBox = true;

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -75,6 +75,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.instances.TestInstances"),
     TestEntry("uk.ac.manchester.tornado.unittests.matrices.TestMatrixTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestAPI"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestInitDataTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.memoryplan.TestMemoryLimit"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/code/CodeUtil.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/code/CodeUtil.java
@@ -21,6 +21,11 @@
  */
 package uk.ac.manchester.tornado.drivers.common.code;
 
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.JavaType;
+import jdk.vm.ci.meta.Local;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.meta.Signature;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.lir.Variable;
 
@@ -28,10 +33,7 @@ import jdk.vm.ci.code.CallingConvention;
 import jdk.vm.ci.code.CallingConvention.Type;
 import jdk.vm.ci.code.CodeCacheProvider;
 import jdk.vm.ci.code.TargetDescription;
-import jdk.vm.ci.meta.JavaKind;
-import jdk.vm.ci.meta.JavaType;
-import jdk.vm.ci.meta.ResolvedJavaMethod;
-import jdk.vm.ci.meta.Signature;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 
 public class CodeUtil {
 
@@ -53,14 +55,21 @@ public class CodeUtil {
         for (int i = 0; i < sigCount; i++) {
             argTypes[argIndex++] = sig.getParameterType(i, null);
         }
-        return getCallingConvention(type, retType, argTypes, codeCache.getTarget());
+
+        final Local[] locals = method.getLocalVariableTable().getLocalsAt(0);
+        return getCallingConvention(type, retType, argTypes, codeCache.getTarget(), locals);
     }
 
-    private static CallingConvention getCallingConvention(Type type, JavaType returnType, JavaType[] argTypes, TargetDescription target) {
+    private static CallingConvention getCallingConvention(Type type, JavaType returnType, JavaType[] argTypes, TargetDescription target, Local[] locals) {
         int variableIndex = 0;
 
         Variable[] inputParameters = new Variable[argTypes.length];
         for (int i = 0; i < argTypes.length; i++, variableIndex++) {
+            if (argTypes[i].toJavaName().equals(HalfFloat.class.getName())) {
+                // Treat HalfFloat as short during code generation
+                inputParameters[i] = new Variable(LIRKind.value(target.arch.getPlatformKind(JavaKind.Short)), variableIndex);
+                continue;
+            }
             inputParameters[i] = new Variable(LIRKind.value(target.arch.getPlatformKind(argTypes[i].getJavaKind())), variableIndex);
 
         }

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/code/CodeUtil.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/code/CodeUtil.java
@@ -65,7 +65,7 @@ public class CodeUtil {
 
         Variable[] inputParameters = new Variable[argTypes.length];
         for (int i = 0; i < argTypes.length; i++, variableIndex++) {
-            if (argTypes[i].toJavaName().equals(HalfFloat.class.getName())) {
+            if (isHalfFloat(argTypes[i])) {
                 // Treat HalfFloat as short during code generation
                 inputParameters[i] = new Variable(LIRKind.value(target.arch.getPlatformKind(JavaKind.Short)), variableIndex);
                 continue;
@@ -81,6 +81,10 @@ public class CodeUtil {
         variableIndex++;
 
         return new CallingConvention(0, returnParameter, inputParameters);
+    }
+
+    public static boolean isHalfFloat(JavaType type) {
+        return type.toJavaName().equals(HalfFloat.class.getName());
     }
 
 }

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/mm/PrimitiveSerialiser.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/mm/PrimitiveSerialiser.java
@@ -25,6 +25,7 @@ package uk.ac.manchester.tornado.drivers.common.mm;
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
 
 public class PrimitiveSerialiser {
@@ -41,10 +42,13 @@ public class PrimitiveSerialiser {
 
     public static void put(ByteBuffer buffer, Object value, int alignment) {
         switch (value) {
-            case Integer intValue -> buffer.putInt(intValue);
-            case Long longValue -> buffer.putLong(longValue);
+            case Byte byteValue -> buffer.put(byteValue);
+            case Character charValue -> buffer.putChar(charValue);
             case Short shortValue -> buffer.putShort(shortValue);
+            case HalfFloat halfFloat -> buffer.putShort(halfFloat.getHalfFloatValue());
+            case Integer intValue -> buffer.putInt(intValue);
             case Float floatValue -> buffer.putFloat(floatValue);
+            case Long longValue -> buffer.putLong(longValue);
             case Double doubleValue -> buffer.putDouble(doubleValue);
             case null, default -> Tornado.warn("unable to serialise: %s (%s)", value, value.getClass().getName());
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -37,6 +37,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.ObjectBuffer;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.drivers.common.mm.PrimitiveSerialiser;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.drivers.opencl.OCLGPUScheduler;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
@@ -26,6 +26,7 @@ package uk.ac.manchester.tornado.drivers.opencl.graal.backend;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
+import static uk.ac.manchester.tornado.drivers.common.code.CodeUtil.isHalfFloat;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG_KERNEL_ARGS;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.ENABLE_EXCEPTIONS;
@@ -360,10 +361,6 @@ public class OCLBackend extends TornadoBackend<OCLProviders> implements FrameMap
             parameterName = "_" + parameterName;
         }
         return parameterName;
-    }
-
-    private boolean isHalfFloat(JavaType type) {
-        return type.toJavaName().equals(HalfFloat.class.getName());
     }
 
     private void emitMethodParameters(OCLAssembler asm, ResolvedJavaMethod method, CallingConvention incomingArguments, boolean isKernel) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
@@ -58,6 +58,7 @@ import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaField;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.analysis.TornadoValueTypeReplacement;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoopUnroller;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLKernelContextAccessNode;
@@ -253,13 +254,17 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
         }
     }
 
-    private ConstantNode createConstantFromObject(Object obj) {
+    private ConstantNode createConstantFromObject(Object obj, StructuredGraph graph) {
         ConstantNode result = null;
         switch (obj) {
-            case Float objFloat -> result = ConstantNode.forFloat(objFloat);
-            case Integer objInteger -> result = ConstantNode.forInt(objInteger);
-            case Double objDouble -> result = ConstantNode.forDouble(objDouble);
-            case Long objLong -> result = ConstantNode.forLong(objLong);
+            case Byte objByte -> result = ConstantNode.forByte(objByte, graph);
+            case Character objChar -> result = ConstantNode.forChar(objChar, graph);
+            case Short objShort -> result = ConstantNode.forShort(objShort, graph);
+            case HalfFloat objHalfFloat -> result = ConstantNode.forFloat(objHalfFloat.getFloat32(), graph);
+            case Integer objInteger -> result = ConstantNode.forInt(objInteger, graph);
+            case Float objFloat -> result = ConstantNode.forFloat(objFloat, graph);
+            case Double objDouble -> result = ConstantNode.forDouble(objDouble, graph);
+            case Long objLong -> result = ConstantNode.forLong(objLong, graph);
             case null, default -> unimplemented("createConstantFromObject: %s", obj);
         }
         return result;
@@ -292,8 +297,7 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
                 parameterNode.replaceAtUsages(kernelContextAccessNode);
                 index++;
             } else {
-                ConstantNode constant = createConstantFromObject(args[parameterNode.index()]);
-                graph.addWithoutUnique(constant);
+                ConstantNode constant = createConstantFromObject(args[parameterNode.index()], graph);
                 parameterNode.replaceAtUsages(constant);
             }
         } else {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLObjectWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLObjectWrapper.java
@@ -47,8 +47,10 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.memory.ObjectBuffer;
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.CharArray;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
@@ -137,6 +139,14 @@ public class OCLObjectWrapper implements ObjectBuffer {
             } else if (type == LongArray.class) {
                 Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
                 long size = ((LongArray) objectFromField).getSegment().byteSize();
+                wrappedField = new OCLMemorySegmentWrapper(size, device, 0);
+            } else if (type == HalfFloatArray.class) {
+                Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
+                long size = ((HalfFloatArray) objectFromField).getSegment().byteSize();
+                wrappedField = new OCLMemorySegmentWrapper(size, device, 0);
+            } else if (type == CharArray.class) {
+                Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
+                long size = ((CharArray) objectFromField).getSegment().byteSize();
                 wrappedField = new OCLMemorySegmentWrapper(size, device, 0);
             } else if (object.getClass().getAnnotation(Vector.class) != null) {
                 wrappedField = new OCLVectorWrapper(device, object, 0);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLObjectWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLObjectWrapper.java
@@ -140,14 +140,6 @@ public class OCLObjectWrapper implements ObjectBuffer {
                 Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
                 long size = ((LongArray) objectFromField).getSegment().byteSize();
                 wrappedField = new OCLMemorySegmentWrapper(size, device, 0);
-            } else if (type == HalfFloatArray.class) {
-                Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
-                long size = ((HalfFloatArray) objectFromField).getSegment().byteSize();
-                wrappedField = new OCLMemorySegmentWrapper(size, device, 0);
-            } else if (type == CharArray.class) {
-                Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
-                long size = ((CharArray) objectFromField).getSegment().byteSize();
-                wrappedField = new OCLMemorySegmentWrapper(size, device, 0);
             } else if (object.getClass().getAnnotation(Vector.class) != null) {
                 wrappedField = new OCLVectorWrapper(device, object, 0);
             } else if (field.getJavaKind().isObject()) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -39,6 +39,7 @@ import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.drivers.common.TornadoBufferProvider;
 import uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXCompilationResult;
 import uk.ac.manchester.tornado.drivers.ptx.mm.PTXKernelArgs;
@@ -251,7 +252,16 @@ public class PTXDeviceContext extends TornadoLogger implements TornadoDeviceCont
                 args.putLong(address);
                 continue;
             } else if (isBoxedPrimitive(arg.getValue()) || arg.getValue().getClass().isPrimitive()) {
-                args.putLong(((Number) arg.getValue()).longValue());
+                if (arg.getValue() instanceof HalfFloat) {
+                    short halfFloat = ((HalfFloat) arg.getValue()).getHalfFloatValue();
+                    args.putLong(((Number) halfFloat).longValue());
+                } else if (arg.getValue() instanceof Number) {
+                    args.putLong(((Number) arg.getValue()).longValue());
+                } else if (arg.getValue() instanceof Character) {
+                    args.putLong((char) arg.getValue());
+                } else {
+                    shouldNotReachHere();
+                }
             } else {
                 shouldNotReachHere();
             }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXCodeUtil.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXCodeUtil.java
@@ -40,6 +40,7 @@ import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.Signature;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDevice;
 import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstants;
@@ -158,7 +159,9 @@ public class PTXCodeUtil {
         for (Object arg : task.getArguments()) {
             sb.append('_');
             Class<?> argClass = arg.getClass();
-            if (RuntimeUtilities.isBoxedPrimitiveClass(argClass)) {
+            if (argClass == HalfFloat.class) {
+                emitSignatureForGenericParameter(sb, arg);
+            } else if (RuntimeUtilities.isBoxedPrimitiveClass(argClass)) {
                 emitSignatureForPrimitiveParameter(sb, arg);
             } else if (argClass.isArray() && RuntimeUtilities.isPrimitiveArray(argClass)) {
                 emitSignatureForArrayParameter(sb, arg, task);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
@@ -24,6 +24,7 @@ package uk.ac.manchester.tornado.drivers.ptx.graal.backend;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
+import static uk.ac.manchester.tornado.drivers.common.code.CodeUtil.isHalfFloat;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
 
 import java.util.Map;
@@ -262,7 +263,7 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
 
         for (int i = 0; i < incomingArguments.getArgumentCount(); i++) {
             if (isKernel) {
-                if (locals[i].getType().getJavaKind().isPrimitive()) {
+                if (locals[i].getType().getJavaKind().isPrimitive() || isHalfFloat(locals[i].getType())) {
                     final AllocatableValue param = incomingArguments.getArgument(i);
                     asm.emit(", ");
                     asm.emit(".param .align 8 .u64 %s", locals[i].getName());

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoTaskSpecialisation.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoTaskSpecialisation.java
@@ -57,6 +57,7 @@ import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaField;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.analysis.TornadoValueTypeReplacement;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoopUnroller;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXKernelContextAccessNode;
@@ -260,13 +261,17 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
         }
     }
 
-    private ConstantNode createConstantFromObject(Object obj) {
+    private ConstantNode createConstantFromObject(Object obj, StructuredGraph graph) {
         ConstantNode result = null;
         switch (obj) {
-            case Float v -> result = ConstantNode.forFloat((float) obj);
-            case Integer i -> result = ConstantNode.forInt((int) obj);
-            case Double v -> result = ConstantNode.forDouble((double) obj);
-            case Long l -> result = ConstantNode.forLong((long) obj);
+            case Byte objByte -> result = ConstantNode.forByte(objByte, graph);
+            case Character objChar -> result = ConstantNode.forChar(objChar, graph);
+            case Short objShort -> result = ConstantNode.forShort(objShort, graph);
+            case HalfFloat objHalfFloat -> result = ConstantNode.forFloat(objHalfFloat.getFloat32(), graph);
+            case Integer objInteger -> result = ConstantNode.forInt(objInteger, graph);
+            case Float objFloat -> result = ConstantNode.forFloat(objFloat, graph);
+            case Double objDouble -> result = ConstantNode.forDouble(objDouble, graph);
+            case Long objLong -> result = ConstantNode.forLong(objLong, graph);
             case null, default -> unimplemented("createConstantFromObject: %s", obj);
         }
         return result;
@@ -296,8 +301,7 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
                 parameterNode.replaceAtUsages(kernelContextAccessNode);
                 index++;
             } else {
-                ConstantNode constant = createConstantFromObject(args[parameterNode.index()]);
-                graph.addWithoutUnique(constant);
+                ConstantNode constant = createConstantFromObject(args[parameterNode.index()], graph);
                 parameterNode.replaceAtUsages(constant);
             }
         } else {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
@@ -35,6 +35,8 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -81,6 +83,8 @@ public final class TornadoCoreRuntime extends TornadoLogger implements TornadoRu
     private static final TornadoCoreRuntime runtime = new TornadoCoreRuntime();
     private static final JVMMapping JVM = new JVMMapping();
     private static final int DEFAULT_DRIVER = 0;
+
+    private static Lock lock = new ReentrantLock();
     private static DebugContext debugContext = null;
     private static OptionValues options;
     private final Map<Object, GlobalObjectState> objectMappings;
@@ -110,9 +114,11 @@ public final class TornadoCoreRuntime extends TornadoLogger implements TornadoRu
     }
 
     public static DebugContext getDebugContext() {
+        lock.lock();
         if (debugContext == null) {
             debugContext = new DebugContext.Builder(getOptions(), new GraalDebugHandlersFactory(new TornadoSnippetReflectionProvider())).build();
         }
+        lock.unlock();
         return debugContext;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -177,9 +177,13 @@ public class TaskUtils {
                 cp.loadReferencedType(bc[i + 2], Bytecodes.INVOKEVIRTUAL);
                 JavaMethod jm = cp.lookupMethod(bc[i + 2], Bytecodes.INVOKEVIRTUAL);
                 switch (jm.getName()) {
+                    case "booleanValue":
+                    case "byteValue":
+                    case "charValue":
+                    case "shortValue":
+                    case "intValue":
                     case "floatValue":
                     case "doubleValue":
-                    case "intValue":
                     case "longValue":
                         continue;
                 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
@@ -55,6 +55,7 @@ import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.Signature;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.TornadoLoopsData;
 
@@ -165,6 +166,8 @@ public final class RuntimeUtilities {
             isBox = true;
         } else if (obj instanceof Short) {
             isBox = true;
+        } else if (obj instanceof HalfFloat) {
+            isBox = true;
         } else if (obj instanceof Integer) {
             isBox = true;
         } else if (obj instanceof Long) {
@@ -195,6 +198,8 @@ public final class RuntimeUtilities {
         } else if (klass == Character.class) {
             isBox = true;
         } else if (klass == Short.class) {
+            isBox = true;
+        } else if (klass == HalfFloat.class) {
             isBox = true;
         } else if (klass == Integer.class) {
             isBox = true;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestInitDataTypes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestInitDataTypes.java
@@ -23,7 +23,14 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
-import uk.ac.manchester.tornado.api.types.arrays.*;
+import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.CharArray;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
#### Description

Fixes the tests in the `TestInitDataTypes` class

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Run the tests, including the `TestInitDataTypes`
```
tornado-test -V uk.ac.manchester.tornado.unittests.api.TestInitDataTypes
```

